### PR TITLE
expose context

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -90,5 +90,6 @@ const CacheConsumer = CacheContext.Consumer;
 
 module.exports = {
     CacheProvider,
-    CacheConsumer
+    CacheConsumer,
+    CacheContext
 };


### PR DESCRIPTION
This PR exposes the underlying context, so it can be easier consumed via `useContext` or `contextType`.